### PR TITLE
gitignore.io 를 이용해 좀 더 신뢰할 수 있는 .gitignore 만들기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,84 +1,197 @@
-.DS_Store
-.idea/shelf
-/confluence/target
-/dependencies/repo
-/android.tests.dependencies
-/dependencies/android.tests.dependencies
-/dist
-/local
-/gh-pages
-/ideaSDK
-/clionSDK
-/android-studio/sdk
+# Created by https://www.toptal.com/developers/gitignore/api/macos,intellij+all,visualstudiocode,kotlin,gradle
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos,intellij+all,visualstudiocode,kotlin,gradle
+
+### Intellij+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
 out/
-/tmp
-/intellij
-workspace.xml
-*.versionsBackup
-/idea/testData/debugger/tinyApp/classes*
-/jps-plugin/testData/kannotator
-/js/js.translator/testData/out/
-/js/js.translator/testData/out-min/
-/js/js.translator/testData/out-pir/
-.gradle/
-/build
-build/
-!**/src/**/build
-!**/test/**/build
-*.iml
-!**/testData/**/*.iml
-.idea/remote-targets.xml
-.idea/libraries/Gradle*.xml
-.idea/libraries/Maven*.xml
-.idea/artifacts/PILL_*.xml
-.idea/artifacts/KotlinPlugin.xml
-.idea/modules
-.idea/runConfigurations/JPS_*.xml
-.idea/runConfigurations/PILL_*.xml
-.idea/runConfigurations/_FP_*.xml
-.idea/runConfigurations/_MT_*.xml
-.idea/libraries
-.idea/modules.xml
-.idea/gradle.xml
-.idea/compiler.xml
-.idea/inspectionProfiles/profiles_settings.xml
-.idea/.name
-.idea/artifacts/dist_auto_*
-.idea/artifacts/dist.xml
-.idea/artifacts/ideaPlugin.xml
-.idea/artifacts/kotlinc.xml
-.idea/artifacts/kotlin_compiler_jar.xml
-.idea/artifacts/kotlin_plugin_jar.xml
-.idea/artifacts/kotlin_jps_plugin_jar.xml
-.idea/artifacts/kotlin_daemon_client_jar.xml
-.idea/artifacts/kotlin_imports_dumper_compiler_plugin_jar.xml
-.idea/artifacts/kotlin_main_kts_jar.xml
-.idea/artifacts/kotlin_compiler_client_embeddable_jar.xml
-.idea/artifacts/kotlin_reflect_jar.xml
-.idea/artifacts/kotlin_stdlib_js_ir_*
-.idea/artifacts/kotlin_test_js_ir_*
-.idea/artifacts/kotlin_dom_api_compat_*
-.idea/artifacts/kotlin_stdlib_wasm_*
-.idea/artifacts/kotlin_test_wasm_*
-.idea/artifacts/kotlinx_atomicfu_runtime_*
-.idea/artifacts/kotlinx_cli_jvm_*
-.idea/jarRepositories.xml
-.idea/csv-plugin.xml
-.idea/libraries-with-intellij-classes.xml
-.idea/misc.xml
-.idea/protoeditor.xml
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
 .idea/sonarlint/
-.idea/codeStyles/
-.idea/*.xml
-.idea/httpRequests/**/*.json
-.idea/httpRequests/*.xml
-node_modules/
-.rpt2_cache/
-libraries/tools/kotlin-test-js-runner/lib/
-local.properties
-buildSrcTmp/
-distTmp/
-outTmp/
-/test.output
-/kotlin-native/dist
-kotlin-ide/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij+all Patch ###
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
+
+.idea/*
+
+#!.idea/codeStyles
+#!.idea/runConfigurations
+
+### Kotlin ###
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+### Gradle ###
+.gradle
+**/build/
+!src/**/build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Avoid ignore Gradle wrappper properties
+!gradle-wrapper.properties
+
+# Cache of project
+.gradletasknamecache
+
+# Eclipse Gradle plugin generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+### Gradle Patch ###
+# Java heap dump
+*.hprof
+
+# End of https://www.toptal.com/developers/gitignore/api/macos,intellij+all,visualstudiocode,kotlin,gradle


### PR DESCRIPTION
이 pr은 gitignore.io 홈페이지를 이용해서 `.gitignore`를 더 좋은 방향으로 작성합니다.

This closes #6 